### PR TITLE
ci: add lint and prisma validation workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: CI
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+permissions:
+  contents: read
+
+jobs:
+  quality:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run lint
+        run: npm run lint
+
+      - name: Run type checks
+        run: npm run typecheck
+
+      - name: Validate Prisma schema
+        run: npm run db:validate

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # WeDefiDaily
 
+[![CI](https://github.com/cjnemes/WeDefiDaily/actions/workflows/ci.yml/badge.svg)](https://github.com/cjnemes/WeDefiDaily/actions/workflows/ci.yml)
+
 Personal DeFi command center focused on Base-native incentives, ve-token governance, and multi-chain portfolio tracking.
 
 ## Monorepo Layout
@@ -24,6 +26,7 @@ Personal DeFi command center focused on Base-native incentives, ve-token governa
 - ESLint + Prettier for consistent code style.
 - Prisma ORM for Postgres-backed persistence.
 - Docker Compose scaffolding for Postgres-backed persistence.
+- GitHub Actions CI pipeline running lint, type checks, and Prisma validation.
 
 ## Next Steps
 - Add Base/Aerodrome data connectors and on-chain sync jobs.
@@ -48,3 +51,9 @@ Personal DeFi command center focused on Base-native incentives, ve-token governa
   ```
 
   Returns `201 Created` for new wallets or `200 OK` when an existing record is reused/updated.
+
+## Useful Commands
+
+- `npm run lint` – lint both workspaces.
+- `npm run typecheck` – run TypeScript type checking across web and API.
+- `npm run db:validate` – ensure the Prisma schema is valid (used by CI).

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -15,7 +15,8 @@
     "prisma:db:push": "dotenv -e ../../.env -- prisma db push",
     "prisma:migrate:dev": "dotenv -e ../../.env -- prisma migrate dev",
     "prisma:migrate:deploy": "dotenv -e ../../.env -- prisma migrate deploy",
-    "prisma:studio": "dotenv -e ../../.env -- prisma studio"
+    "prisma:studio": "dotenv -e ../../.env -- prisma studio",
+    "prisma:validate": "dotenv -e ../../.env.example -- prisma validate"
   },
   "dependencies": {
     "@fastify/cors": "^10.0.1",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "db:push": "npm run prisma:db:push --workspace @wedefidaily/api",
     "db:migrate:dev": "npm run prisma:migrate:dev --workspace @wedefidaily/api",
     "db:migrate:deploy": "npm run prisma:migrate:deploy --workspace @wedefidaily/api",
-    "db:studio": "npm run prisma:studio --workspace @wedefidaily/api"
+    "db:studio": "npm run prisma:studio --workspace @wedefidaily/api",
+    "db:validate": "npm run prisma:validate --workspace @wedefidaily/api"
   },
   "workspaces": [
     "apps/web",


### PR DESCRIPTION
## Summary\n- run lint, typecheck, and Prisma schema validation via GitHub Actions on pushes/PRs to main\n- add reusable npm scripts (db:validate) and prisma validate command hooked to .env.example\n- document CI badge, useful commands, and tooling updates in README\n\n## Testing\n- npm run lint\n- npm run typecheck\n- npm run db:validate\n\nCloses #5